### PR TITLE
Fix losing focus on XWayland floating windows after input method usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,19 @@ event won't be triggered until your next mouse movement. The easiest way to
 scroll is to flick the mouse inside and outside of the gap to make sure you
 only scroll once.
 
+### `avoid_focus_on_xwayland_float_close`
+
+Some input methods (IMEs) on XWayland create temporary floating windows
+like candidate popups while typing. These windows may be quickly removed.
+
+When such a window closes, hyprscroller may change focus to another window.
+For XWayland floating windows, this can cause input methods to lose focus.
+
+This setting disables focus changes only when an XWayland floating window
+is removed. Other windows are unaffected.
+
+Default is `0` (off). Enable it if you face input focus problems with XWayland:
+
 ### `cyclesize_wrap`
 
 If `true`, `cyclesize`, `cyclewidth` and `cycleheight` will cycle through all

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,6 +84,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:scroller:jump_labels_scale", Hyprlang::FLOAT{0.5});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:scroller:jump_labels_color", Hyprlang::INT{0x80159e30});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:scroller:jump_labels_keys", Hyprlang::STRING{"1234"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:scroller:avoid_focus_on_xwayland_float_close", Hyprlang::INT{0});// 0, 1
 
     HyprlandAPI::reloadConfig();
 

--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -392,8 +392,13 @@ void ScrollerLayout::onWindowRemovedTiling(PHLWINDOW window)
 /*
     Called when a floating window is removed (unmapped)
 */
-void ScrollerLayout::onWindowRemovedFloating(PHLWINDOW)
+void ScrollerLayout::onWindowRemovedFloating(PHLWINDOW window)
 {
+    if (window && window->m_isX11) {
+        // Avoid automatic focus switch when an XWayland floating window is removed,
+        // to prevent input method losing focus
+        return;
+    }
     WORKSPACEID workspace_id = g_pCompositor->m_lastMonitor->activeSpecialWorkspaceID();
     if (!workspace_id) {
         workspace_id = g_pCompositor->m_lastMonitor->activeWorkspaceID();

--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -394,7 +394,8 @@ void ScrollerLayout::onWindowRemovedTiling(PHLWINDOW window)
 */
 void ScrollerLayout::onWindowRemovedFloating(PHLWINDOW window)
 {
-    if (window && window->m_isX11) {
+    static auto* const *avoid_focus = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:scroller:avoid_focus_on_xwayland_float_close")->getDataStaticPtr();
+    if (window && window->m_isX11 && **avoid_focus) {
         // Avoid automatic focus switch when an XWayland floating window is removed,
         // to prevent input method losing focus
         return;


### PR DESCRIPTION
Thanks for maintaining this project!
This PR fixes an issue where XWayland floating windows lose focus after input method usage (e.g. typing with an IME).

https://github.com/user-attachments/assets/23b29051-2fba-439f-8343-302370be111e



