### PR TITLE
feat: switch workspace on movefocus up/down

### DIFF
--- a/src/column.cpp
+++ b/src/column.cpp
@@ -303,7 +303,7 @@ bool Column::move_focus_up(bool focus_wrap)
                 return true;
             }
             else{
-                g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+                g_pKeybindManager->m_dispatchers["workspace"]("m-1");
                 return false;
             }
         }
@@ -326,7 +326,7 @@ bool Column::move_focus_down(bool focus_wrap)
                 return true;
             }
             else{
-                g_pKeybindManager->m_mDispatchers["workspace"]("m+1");
+                g_pKeybindManager->m_dispatchers["workspace"]("m+1");
                 return false;
             }
         }

--- a/src/column.cpp
+++ b/src/column.cpp
@@ -298,9 +298,14 @@ bool Column::move_focus_up(bool focus_wrap)
     if (active == windows.first()) {
         PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('u');
         if (monitor == nullptr) {
-            if (focus_wrap)
+            if (focus_wrap){
                 active = windows.last();
-            return true;
+                return true;
+            }
+            else{
+                g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+                return false;
+            }
         }
         // use default dispatch for movefocus (change monitor)
         orig_moveFocusTo("u");
@@ -316,9 +321,14 @@ bool Column::move_focus_down(bool focus_wrap)
     if (active == windows.last()) {
         PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('d');
         if (monitor == nullptr) {
-            if (focus_wrap)
+            if (focus_wrap){
                 active = windows.first();
-            return true;
+                return true;
+            }
+            else{
+                g_pKeybindManager->m_mDispatchers["workspace"]("m+1");
+                return false;
+            }
         }
         // use default dispatch for movefocus (change monitor)
         orig_moveFocusTo("d");

--- a/src/column.cpp
+++ b/src/column.cpp
@@ -302,7 +302,10 @@ bool Column::move_focus_up(bool focus_wrap)
                 active = windows.last();
                 return true;
             } else {
-                g_pKeybindManager->m_dispatchers["workspace"]("m-1");
+                static auto* const *movefocus_changes_workspace = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:scroller:movefocus_changes_workspace")->getDataStaticPtr();
+                if (**movefocus_changes_workspace) {
+                    g_pKeybindManager->m_dispatchers["workspace"]("m-1");
+                }
                 return false;
             }
         }
@@ -324,7 +327,10 @@ bool Column::move_focus_down(bool focus_wrap)
                 active = windows.first();
                 return true;
             } else {
-                g_pKeybindManager->m_dispatchers["workspace"]("m+1");
+                static auto* const *movefocus_changes_workspace = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:scroller:movefocus_changes_workspace")->getDataStaticPtr();
+                if (**movefocus_changes_workspace) {
+                    g_pKeybindManager->m_dispatchers["workspace"]("m+1");
+                }
                 return false;
             }
         }

--- a/src/column.cpp
+++ b/src/column.cpp
@@ -298,11 +298,10 @@ bool Column::move_focus_up(bool focus_wrap)
     if (active == windows.first()) {
         PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('u');
         if (monitor == nullptr) {
-            if (focus_wrap){
+            if (focus_wrap) {
                 active = windows.last();
                 return true;
-            }
-            else{
+            } else {
                 g_pKeybindManager->m_dispatchers["workspace"]("m-1");
                 return false;
             }
@@ -321,11 +320,10 @@ bool Column::move_focus_down(bool focus_wrap)
     if (active == windows.last()) {
         PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('d');
         if (monitor == nullptr) {
-            if (focus_wrap){
+            if (focus_wrap) {
                 active = windows.first();
                 return true;
-            }
-            else{
+            } else {
                 g_pKeybindManager->m_dispatchers["workspace"]("m+1");
                 return false;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:scroller:window_default_height", Hyprlang::STRING{"one"});
     // 0, 1
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:scroller:focus_wrap", Hyprlang::INT{1});
+    // 0, 1
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:scroller:movefocus_changes_workspace", Hyprlang::INT{0});
     // 0, inf
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:scroller:focus_edge_ms", Hyprlang::INT{400});
     // 0, 1

--- a/src/row.cpp
+++ b/src/row.cpp
@@ -298,7 +298,7 @@ bool Row::move_focus_left(bool focus_wrap)
                 return true;
             }
             // else{
-            //     g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+            //     g_pKeybindManager->m_dispatchers["workspace"]("m-1");
             //     return false;
             // }
         }
@@ -320,7 +320,7 @@ bool Row::move_focus_right(bool focus_wrap)
                 return true;
             }
             // else{
-            //     g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+            //     g_pKeybindManager->m_dispatchers["workspace"]("m-1");
             //     return false;
             // }
         }

--- a/src/row.cpp
+++ b/src/row.cpp
@@ -293,14 +293,10 @@ bool Row::move_focus_left(bool focus_wrap)
     if (active == columns.first()) {
         PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('l');
         if (monitor == nullptr) {
-            if (focus_wrap){
+            if (focus_wrap) {
                 active = columns.last();
                 return true;
             }
-            // else{
-            //     g_pKeybindManager->m_dispatchers["workspace"]("m-1");
-            //     return false;
-            // }
         }
 
         orig_moveFocusTo("l");
@@ -315,14 +311,10 @@ bool Row::move_focus_right(bool focus_wrap)
     if (active == columns.last()) {
         PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('r');
         if (monitor == nullptr) {
-            if (focus_wrap){
+            if (focus_wrap) {
                 active = columns.first();
                 return true;
             }
-            // else{
-            //     g_pKeybindManager->m_dispatchers["workspace"]("m-1");
-            //     return false;
-            // }
         }
 
         orig_moveFocusTo("r");

--- a/src/row.cpp
+++ b/src/row.cpp
@@ -293,9 +293,14 @@ bool Row::move_focus_left(bool focus_wrap)
     if (active == columns.first()) {
         PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('l');
         if (monitor == nullptr) {
-            if (focus_wrap)
+            if (focus_wrap){
                 active = columns.last();
-            return true;
+                return true;
+            }
+            // else{
+            //     g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+            //     return false;
+            // }
         }
 
         orig_moveFocusTo("l");
@@ -310,9 +315,14 @@ bool Row::move_focus_right(bool focus_wrap)
     if (active == columns.last()) {
         PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('r');
         if (monitor == nullptr) {
-            if (focus_wrap)
+            if (focus_wrap){
                 active = columns.first();
-            return true;
+                return true;
+            }
+            // else{
+            //     g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+            //     return false;
+            // }
         }
 
         orig_moveFocusTo("r");

--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -899,17 +899,23 @@ void ScrollerLayout::move_focus(WORKSPACEID workspace, Direction direction)
                 orig_moveFocusTo("r");
                 break;
             case Direction::Up:
-                if (g_pCompositor->getMonitorInDirection('u') == nullptr) {
-                    g_pKeybindManager->m_dispatchers["workspace"]("m-1");
-                } else {
-                    orig_moveFocusTo("u");
+                {
+                    static auto* const *movefocus_changes_workspace = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:scroller:movefocus_changes_workspace")->getDataStaticPtr();
+                    if (**movefocus_changes_workspace && g_pCompositor->getMonitorInDirection('u') == nullptr) {
+                        g_pKeybindManager->m_dispatchers["workspace"]("m-1");
+                    } else {
+                        orig_moveFocusTo("u");
+                    }
                 }
                 break;
             case Direction::Down:
-                if (g_pCompositor->getMonitorInDirection('d') == nullptr) {
-                    g_pKeybindManager->m_dispatchers["workspace"]("m+1");
-                } else {
-                    orig_moveFocusTo("d");
+                {
+                    static auto* const *movefocus_changes_workspace = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:scroller:movefocus_changes_workspace")->getDataStaticPtr();
+                    if (**movefocus_changes_workspace && g_pCompositor->getMonitorInDirection('d') == nullptr) {
+                        g_pKeybindManager->m_dispatchers["workspace"]("m+1");
+                    } else {
+                        orig_moveFocusTo("d");
+                    }
                 }
                 break;
             default:

--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -893,34 +893,22 @@ void ScrollerLayout::move_focus(WORKSPACEID workspace, Direction direction)
         // is "move to another monitor" (pass the direction)
         switch (direction) {
             case Direction::Left:
-                // if (g_pCompositor->getMonitorInDirection('l') == nullptr){
-                //     g_pKeybindManager->m_dispatchers["workspace"]("m-1");
-                // }
-                // else{
-                    orig_moveFocusTo("l");
-                // }
+                orig_moveFocusTo("l");
                 break;
             case Direction::Right:
-                // if (g_pCompositor->getMonitorInDirection('r') == nullptr){
-                //     g_pKeybindManager->m_dispatchers["workspace"]("m+1");
-                // }
-                // else{
-                    orig_moveFocusTo("r");
-                // }
+                orig_moveFocusTo("r");
                 break;
             case Direction::Up:
-                if (g_pCompositor->getMonitorInDirection('u') == nullptr){
+                if (g_pCompositor->getMonitorInDirection('u') == nullptr) {
                     g_pKeybindManager->m_dispatchers["workspace"]("m-1");
-                }
-                else{
+                } else {
                     orig_moveFocusTo("u");
                 }
                 break;
             case Direction::Down:
-                if (g_pCompositor->getMonitorInDirection('d') == nullptr){
+                if (g_pCompositor->getMonitorInDirection('d') == nullptr) {
                     g_pKeybindManager->m_dispatchers["workspace"]("m+1");
-                }
-                else{
+                } else {
                     orig_moveFocusTo("d");
                 }
                 break;

--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -894,7 +894,7 @@ void ScrollerLayout::move_focus(WORKSPACEID workspace, Direction direction)
         switch (direction) {
             case Direction::Left:
                 // if (g_pCompositor->getMonitorInDirection('l') == nullptr){
-                //     g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+                //     g_pKeybindManager->m_dispatchers["workspace"]("m-1");
                 // }
                 // else{
                     orig_moveFocusTo("l");
@@ -902,7 +902,7 @@ void ScrollerLayout::move_focus(WORKSPACEID workspace, Direction direction)
                 break;
             case Direction::Right:
                 // if (g_pCompositor->getMonitorInDirection('r') == nullptr){
-                //     g_pKeybindManager->m_mDispatchers["workspace"]("m+1");
+                //     g_pKeybindManager->m_dispatchers["workspace"]("m+1");
                 // }
                 // else{
                     orig_moveFocusTo("r");
@@ -910,7 +910,7 @@ void ScrollerLayout::move_focus(WORKSPACEID workspace, Direction direction)
                 break;
             case Direction::Up:
                 if (g_pCompositor->getMonitorInDirection('u') == nullptr){
-                    g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+                    g_pKeybindManager->m_dispatchers["workspace"]("m-1");
                 }
                 else{
                     orig_moveFocusTo("u");
@@ -918,7 +918,7 @@ void ScrollerLayout::move_focus(WORKSPACEID workspace, Direction direction)
                 break;
             case Direction::Down:
                 if (g_pCompositor->getMonitorInDirection('d') == nullptr){
-                    g_pKeybindManager->m_mDispatchers["workspace"]("m+1");
+                    g_pKeybindManager->m_dispatchers["workspace"]("m+1");
                 }
                 else{
                     orig_moveFocusTo("d");

--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -1512,7 +1512,29 @@ void ScrollerLayout::swipe_end(SCallbackInfo &info,
     // Only if scrolling
     if (swipe_direction != Direction::Begin) {
         auto s = getRowForWorkspace(wid);
-        s->scroll_end(swipe_direction);
+        if (s) {
+            auto from = s->get_active_window();
+            s->scroll_end(swipe_direction);
+            auto to = s->get_active_window();
+
+            if (from == to) {
+                // scroll hit an edge and couldn't move
+                static auto* const *movefocus_changes_workspace = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:scroller:movefocus_changes_workspace")->getDataStaticPtr();
+                if (**movefocus_changes_workspace) {
+                    if (swipe_direction == Direction::Up) { // Swipe down gesture
+                        PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('d');
+                        if (monitor == nullptr) {
+                            g_pKeybindManager->m_dispatchers["workspace"]("m+1");
+                        }
+                    } else if (swipe_direction == Direction::Down) { // Swipe up gesture
+                        PHLMONITOR monitor = g_pCompositor->getMonitorInDirection('u');
+                        if (monitor == nullptr) {
+                            g_pKeybindManager->m_dispatchers["workspace"]("m-1");
+                        }
+                    }
+                }
+            }
+        }
     }
 
     swipe_active = false;

--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -893,16 +893,36 @@ void ScrollerLayout::move_focus(WORKSPACEID workspace, Direction direction)
         // is "move to another monitor" (pass the direction)
         switch (direction) {
             case Direction::Left:
-                orig_moveFocusTo("l");
+                // if (g_pCompositor->getMonitorInDirection('l') == nullptr){
+                //     g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+                // }
+                // else{
+                    orig_moveFocusTo("l");
+                // }
                 break;
             case Direction::Right:
-                orig_moveFocusTo("r");
+                // if (g_pCompositor->getMonitorInDirection('r') == nullptr){
+                //     g_pKeybindManager->m_mDispatchers["workspace"]("m+1");
+                // }
+                // else{
+                    orig_moveFocusTo("r");
+                // }
                 break;
             case Direction::Up:
-                orig_moveFocusTo("u");
+                if (g_pCompositor->getMonitorInDirection('u') == nullptr){
+                    g_pKeybindManager->m_mDispatchers["workspace"]("m-1");
+                }
+                else{
+                    orig_moveFocusTo("u");
+                }
                 break;
             case Direction::Down:
-                orig_moveFocusTo("d");
+                if (g_pCompositor->getMonitorInDirection('d') == nullptr){
+                    g_pKeybindManager->m_mDispatchers["workspace"]("m+1");
+                }
+                else{
+                    orig_moveFocusTo("d");
+                }
                 break;
             default:
                 break;


### PR DESCRIPTION
Allows for switching workspaces with `scroller:movefocus` if:
- `plugin:scroller:focus_wrap` is set to `false`
- `plugin:scroller:movefocus_changes_workspace` is set to `true`
