### PR TITLE
fix: perform crude memory regression to prevent fatal build errors

### DIFF
--- a/src/decorations.cpp
+++ b/src/decorations.cpp
@@ -93,7 +93,7 @@ void SelectionBorders::draw(PHLMONITOR pMonitor, float const& a) {
         data.lerp     = m_pWindow->m_borderFadeAnimationProgress->value();
     }
 
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(data));
+    g_pHyprRenderer->m_renderPass.add(makeShared<CBorderPassElement>(data));
 }
 
 eDecorationType SelectionBorders::getDecorationType() {
@@ -233,7 +233,7 @@ void JumpDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     CTexPassElement::SRenderData data;
     data.tex = m_pTexture;
     data.box = windowBox;
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(data));
+    g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(data));
 }
 
 eDecorationType JumpDecoration::getDecorationType() {

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -76,10 +76,10 @@ static void hookRenderLayer(void *thisptr, PHLLS layer, PHLMONITOR monitor, cons
         SRenderModifData modif_data;
         modif_data.modifs.push_back({SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, data.scale_i});
         modif_data.enabled = true;
-        g_pHyprRenderer->m_renderPass.add(makeUnique<OverviewPassElement>(OverviewPassElement::OverviewModifData(modif_data)));
+        g_pHyprRenderer->m_renderPass.add(makeShared<OverviewPassElement>(OverviewPassElement::OverviewModifData(modif_data)));
         g_pHyprRenderer->damageMonitor(monitor);
         ((origRenderLayer)(g_pRenderLayerHook->m_original))(thisptr, layer, monitor, time, popups, lockscreen);
-        g_pHyprRenderer->m_renderPass.add(makeUnique<OverviewPassElement>(OverviewPassElement::OverviewModifData(SRenderModifData())));
+        g_pHyprRenderer->m_renderPass.add(makeShared<OverviewPassElement>(OverviewPassElement::OverviewModifData(SRenderModifData())));
         monitor->m_size = monitor_size;
         return;
     }


### PR DESCRIPTION
reverts 3190d91ffce99000f9f1ac262dc1a11dd83970b6, closes #13 

Note: I have no idea how Hyprland's memory model works, so I do not know what the intention is for the changes in how pointers are handled (as evidenced by https://github.com/hyprwm/aquamarine/pull/128); however, I can confirm reverting this commit fixes the build errors introduced and no other changes to future updates need to made for this fix to take effect

If there is a better way of doing this, please let me know!