### PR TITLE
fix double-unmap windows

### DIFF
--- a/src/window.h
+++ b/src/window.h
@@ -10,7 +10,9 @@ class Window {
 public:
     Window(PHLWINDOW window, double maxy, double box_h, StandardSize width);
     ~Window() {
-        window->removeWindowDeco(decoration);
+        if (const auto w = window.lock()) {
+            w->removeWindowDeco(decoration);
+        }
     }
     PHLWINDOW get_window() { return window.lock(); }
     double get_geom_h() const { return box_h; }


### PR DESCRIPTION
Got one-more random crash of Hyprland with Hyprscroller. This fix I don't tested on my PC, because don't know how to reproduce crash, but I hope this crash was fixed.

In short `hyprscroller::Row::~Row` produces call `Desktop::View::CWindow::unmapWindow` for already unmaped window
<details>
  <summary>Here is full crash report</summary>

```
--------------------------------------------
   Hyprland Crash Report
--------------------------------------------
Maybe you should try dusting your PC in the meantime?

Hyprland received signal 11(SEGV)
Version: 0de216e783d02748183ac5a5712201517685f492
Tag: v0.53.0-140-g0de216e78
Date: Tue Feb 17 13:57:46 2026
Flags:

Hyprland seems to be running with plugins. This crash might not be Hyprland's fault.
Plugins:
	hyprgrass (horriblename) v0.8.2
	hyprscroller (dawser) 1.0


System info:
	System name: Linux
	Node name: srbox
	Release: 6.18.9-zen1-2-zen
	Version: #1 ZEN SMP PREEMPT_DYNAMIC Mon, 09 Feb 2026 17:45:06 +0000

GPU:
	01:00.0 VGA compatible controller [0300]: NVIDIA Corporation AD104 [GeForce RTX 4070] [10de:2786] (rev a1) (prog-if 00 [VGA controller])


os-release:
	NAME="CachyOS Linux"
	PRETTY_NAME="CachyOS"
	ID=cachyos
	ID_LIKE=arch
	BUILD_ID=rolling
	ANSI_COLOR="38;2;23;147;209"
	HOME_URL="https://cachyos.org/"
	DOCUMENTATION_URL="https://wiki.cachyos.org/"
	SUPPORT_URL="https://discuss.cachyos.org/"
	BUG_REPORT_URL="https://github.com/cachyos"
	PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
	LOGO=cachyos

Libraries:
Hyprgraphics: built against 0.5.0, system has 0.5.0
Hyprutils: built against 0.11.0, system has 0.11.0
Hyprcursor: built against 0.1.13, system has 0.1.13
Hyprlang: built against 0.6.8, system has 0.6.8
Aquamarine: built against 0.10.0, system has 0.10.0

Backtrace:
	# | Hyprland(_Z12getBacktracev+0x61) [0x562d8d914a21]
		getBacktrace()
		??:?
	#1 | Hyprland(_ZN13CrashReporter18createAndSaveCrashEi+0xcd6) [0x562d8d87df66]
		CrashReporter::createAndSaveCrash(int)
		??:?
	#2 | Hyprland(+0x261d82) [0x562d8d7cdd82]
		std::__format::_Formatting_scanner<std::__format::_Sink_iter<char>, char>::_M_format_arg(unsigned long)
		??:?
	#3 | /usr/lib/libc.so.6(+0x3e2d0) [0x7ff5eb63e2d0]
		??
		??:0
	#4 | /home/sr_team/Public/hyprscroller/hyprscroller.so(_ZN3RowD1Ev+0x7) [0x7ff5d169d127]
		??
		??:0
	#5 | /home/sr_team/Public/hyprscroller/hyprscroller.so(_ZN14ScrollerLayout21onWindowRemovedTilingEN9Hyprutils6Memory14CSharedPointerIN7Desktop4View7CWindowEEE+0x51e) [0x7ff5d167023e]
		??
		??:0
	#6 | Hyprland(_ZN11IHyprLayout15onWindowRemovedEN9Hyprutils6Memory14CSharedPointerIN7Desktop4View7CWindowEEE+0x2fc) [0x562d8d9a0d6c]
		IHyprLayout::onWindowRemoved(Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>)
		??:?
	#7 | Hyprland(_ZN7Desktop4View7CWindow11unmapWindowEv+0xd5c) [0x562d8d8f37ac]
		Desktop::View::CWindow::unmapWindow()
		??:?
	#8 | /usr/lib/libhyprutils.so.10(_ZN9Hyprutils6Signal15CSignalListener12emitInternalEPv+0x2d) [0x7ff5ec65b41d]
		??
		??:0
	#9 | /usr/lib/libhyprutils.so.10(_ZN9Hyprutils6Signal11CSignalBase12emitInternalEPv+0x2c3) [0x7ff5ec65b7a3]
		??
		??:0
	#1 | Hyprland(+0x6d26ca) [0x562d8dc3e6ca]
		CXDGPositionerRules::getPosition(Hyprutils::Math::CBox, Hyprutils::Math::Vector2D const&)
		??:?
	#11 | /usr/lib/libhyprutils.so.10(_ZN9Hyprutils6Signal15CSignalListener12emitInternalEPv+0x2d) [0x7ff5ec65b41d]
		??
		??:0
	#12 | /usr/lib/libhyprutils.so.10(_ZN9Hyprutils6Signal11CSignalBase12emitInternalEPv+0x2c3) [0x7ff5ec65b7a3]
		??
		??:0
	#13 | Hyprland(_ZN18CWLSurfaceResource7destroyEv+0xc2) [0x562d8dc4b732]
		CWLSurfaceResource::destroy()
		??:?
	#14 | Hyprland(+0x81d9a3) [0x562d8dd899a3]
		CWpCommitTimerV1::setDestroy(std::function<void (CWpCommitTimerV1*)>&&)
		??:?
	#15 | /usr/lib/libwayland-server.so.0(+0xb16f) [0x7ff5ec51216f]
		??
		??:0
	#16 | /usr/lib/libwayland-server.so.0(wl_client_destroy+0xb2) [0x7ff5ec512372]
		??
		??:0
	#17 | /usr/lib/libwayland-server.so.0(+0xb5c2) [0x7ff5ec5125c2]
		??
		??:0
	#18 | /usr/lib/libwayland-server.so.0(wl_event_loop_dispatch+0x332) [0x7ff5ec511872]
		??
		??:0
	#19 | /usr/lib/libwayland-server.so.0(wl_display_run+0x27) [0x7ff5ec513987]
		??
		??:0
	#2 | Hyprland(_ZN17CEventLoopManager9enterLoopEv+0x2c1) [0x562d8da607f1]
		CEventLoopManager::enterLoop()
		??:?
	#21 | Hyprland(main+0x1476) [0x562d8d756956]
		main
		??:?
	#22 | /usr/lib/libc.so.6(+0x276c1) [0x7ff5eb6276c1]
		??
		??:0
	#23 | /usr/lib/libc.so.6(__libc_start_main+0x89) [0x7ff5eb6277f9]
		??
		??:0
	#24 | Hyprland(_start+0x25) [0x562d8d7b8785]
		_start
		??:?


Log tail:
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Modesetting HDMI-A-1 with 1920x1200@60.00Hz
ERR from aquamarine ]: drm: Cannot commit when a page-flip is awaiting
DEBUG from aquamarine ]: atomic drm request: failed to commit: Invalid argument, flags: ATOMIC_ALLOW_MODESET ATOMIC_TEST_ONLY 
DEBUG from aquamarine ]: drm: Modesetting DP-1 with 3440x1440@99.98Hz
ERR from aquamarine ]: drm: Cannot commit when a page-flip is awaiting
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Modesetting HDMI-A-1 with 1920x1200@60.00Hz
DEBUG from aquamarine ]: drm: Modesetting DP-1 with 3440x1440@99.98Hz
DEBUG from aquamarine ]: drm: Modesetting HDMI-A-1 with 1920x1200@60.00Hz
ERR from aquamarine ]: drm: Cannot commit when a page-flip is awaiting
DEBUG from aquamarine ]: atomic drm request: failed to commit: Invalid argument, flags: ATOMIC_ALLOW_MODESET ATOMIC_TEST_ONLY 
DEBUG from aquamarine ]: drm: Modesetting DP-1 with 3440x1440@99.98Hz
ERR from aquamarine ]: drm: Cannot commit when a page-flip is awaiting
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Modesetting DP-1 with 3440x1440@99.98Hz
DEBUG from aquamarine ]: drm: Modesetting HDMI-A-1 with 1920x1200@60.00Hz
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 165
DEBUG from aquamarine ]: drm: Cursor buffer imported into KMS with id 160
```
</details>